### PR TITLE
Added missing parameters from bitpay API docs

### DIFF
--- a/src/Omnipay/BitPay/Message/PurchaseRequest.php
+++ b/src/Omnipay/BitPay/Message/PurchaseRequest.php
@@ -81,123 +81,32 @@ class PurchaseRequest extends AbstractRequest
         return $this->setParameter('physical', $value);
     }
 
-    public function getBuyerName()
-    {
-        return $this->getParameter('buyerName');
-    }
-
-    public function setBuyerName($value)
-    {
-        return $this->setParameter('buyerName', $value);
-    }
-
-    public function getBuyerAddress1()
-    {
-        return $this->getParameter('buyerAddress1');
-    }
-
-    public function setBuyerAddress1($value)
-    {
-        return $this->setParameter('buyerAddress1', $value);
-    }
-
-    public function getBuyerAddress2()
-    {
-        return $this->getParameter('buyerAddress2');
-    }
-
-    public function setBuyerAddress2($value)
-    {
-        return $this->setParameter('buyerAddress2', $value);
-    }
-
-    public function getBuyerCity()
-    {
-        return $this->getParameter('buyerCity');
-    }
-
-    public function setBuyerCity($value)
-    {
-        return $this->setParameter('buyerCity', $value);
-    }
-
-    public function getBuyerState()
-    {
-        return $this->getParameter('buyerState');
-    }
-
-    public function setBuyerState($value)
-    {
-        return $this->setParameter('buyerState', $value);
-    }
-
-    public function getBuyerZip()
-    {
-        return $this->getParameter('buyerZip');
-    }
-
-    public function setBuyerZip($value)
-    {
-        return $this->setParameter('buyerZip', $value);
-    }
-
-    public function getBuyerCountry()
-    {
-        return $this->getParameter('buyerCountry');
-    }
-
-    public function setBuyerCountry($value)
-    {
-        return $this->setParameter('buyerCountry', $value);
-    }
-
-    public function getBuyerEmail()
-    {
-        return $this->getParameter('buyerEmail');
-    }
-
-    public function setBuyerEmail($value)
-    {
-        return $this->setParameter('buyerEmail', $value);
-    }
-
-    public function getBuyerPhone()
-    {
-        return $this->getParameter('buyerPhone');
-    }
-
-    public function setBuyerPhone($value)
-    {
-        return $this->setParameter('buyerPhone', $value);
-    }
-
     public function getData()
     {
         $this->validate('amount', 'currency');
 
-        $data = array(
-            'price' => $this->getAmount(),
-            'currency' => $this->getCurrency(),
-            'posData' => $this->getTransactionId(),
-            'itemDesc' => $this->getDescription(),
-            'notificationURL' => $this->getNotifyUrl(),
-            'redirectURL' => $this->getReturnUrl(),
-            'notificationEmail' => $this->getNotifyEmail(),
-            'fullNotifications' => $this->getFullNotifications(),
-            'transactionSpeed' => $this->getTransactionSpeed(),
-            'orderID' => $this->getOrderId(),
-            'itemCode' => $this->getItemCode(),
-            'physical' => $this->getPhysical(),
-            'buyerName' => $this->getBuyerName(),
-            'buyerAddress1' => $this->getBuyerAddress1(),
-            'buyerAddress2' => $this->getBuyerAddress2(),
-            'buyerCity' => $this->getBuyerCity(),
-            'buyerState' => $this->getBuyerState(),
-            'buyerZip' => $this->getBuyerZip(),
-            'buyerCountry' => $this->getBuyerCountry(),
-            'buyerEmail' => $this->getBuyerEmail(),
-            'buyerPhone' => $this->getBuyerPhone(),
-        );
+        $data = array();
+        $data['price'] = $this->getAmount();
+        $data['currency'] = $this->getCurrency();
+        $data['posData'] = $this->getTransactionId();
+        $data['itemDesc'] = $this->getDescription();
+        $data['notificationURL'] = $this->getNotifyUrl();
+        $data['redirectURL'] = $this->getReturnUrl();
+        $data['notificationEmail'] = $this->getNotifyEmail();
+        $data['fullNotifications'] = $this->getFullNotifications();
+        $data['transactionSpeed'] = $this->getTransactionSpeed();
+        $data['orderID'] = $this->getOrderId();
+        $data['itemCode'] = $this->getItemCode();
+        $data['physical'] = $this->getPhysical();
+        $data['buyerName'] = $this->getCard()->getName();
+        $data['buyerAddress1'] = $this->getCard()->getAddress1();
+        $data['buyerAddress2'] = $this->getCard()->getAddress2();
+        $data['buyerCity'] = $this->getCard()->getCity();
+        $data['buyerState'] = $this->getCard()->getState();
+        $data['buyerZip'] = $this->getCard()->getBillingPostcode();
+        $data['buyerCountry'] = $this->getCard()->getCountry();
+        $data['buyerEmail'] = $this->getCard()->getEmail();
+        $data['buyerPhone'] = $this->getCard()->getPhone();
 
         return $data;
     }

--- a/src/Omnipay/BitPay/Message/PurchaseRequest.php
+++ b/src/Omnipay/BitPay/Message/PurchaseRequest.php
@@ -175,7 +175,7 @@ class PurchaseRequest extends AbstractRequest
     {
         $this->validate('amount', 'currency');
 
-        $data = [
+        $data = array(
             'price' => $this->getAmount(),
             'currency' => $this->getCurrency(),
             'posData' => $this->getTransactionId(),
@@ -197,7 +197,7 @@ class PurchaseRequest extends AbstractRequest
             'buyerCountry' => $this->getBuyerCountry(),
             'buyerEmail' => $this->getBuyerEmail(),
             'buyerPhone' => $this->getBuyerPhone(),
-        ];
+        );
 
         return $data;
     }

--- a/src/Omnipay/BitPay/Message/PurchaseRequest.php
+++ b/src/Omnipay/BitPay/Message/PurchaseRequest.php
@@ -21,17 +21,183 @@ class PurchaseRequest extends AbstractRequest
         return $this->setParameter('apiKey', $value);
     }
 
+    public function getNotifyEmail()
+    {
+        return $this->getParameter('notifyEmail');
+    }
+
+    public function setNotifyEmail($value)
+    {
+        return $this->setParameter('notifyEmail', $value);
+    }
+
+    public function getFullNotifications()
+    {
+        return $this->getParameter('fullNotifications');
+    }
+
+    public function setFullNotifications($value)
+    {
+        return $this->setParameter('fullNotifications', $value);
+    }
+
+    public function getTransactionSpeed()
+    {
+        return $this->getParameter('transactionSpeed');
+    }
+
+    public function setTransactionSpeed($value)
+    {
+        return $this->setParameter('transactionSpeed', $value);
+    }
+
+    public function getOrderId()
+    {
+        return $this->getParameter('orderId');
+    }
+
+    public function setOrderId($value)
+    {
+        return $this->setParameter('orderId', $value);
+    }
+
+    public function getItemCode()
+    {
+        return $this->getParameter('itemCode');
+    }
+
+    public function setItemCode($value)
+    {
+        return $this->setParameter('itemCode', $value);
+    }
+
+    public function getPhysical()
+    {
+        return $this->getParameter('physical');
+    }
+
+    public function setPhysical($value)
+    {
+        return $this->setParameter('physical', $value);
+    }
+
+    public function getBuyerName()
+    {
+        return $this->getParameter('buyerName');
+    }
+
+    public function setBuyerName($value)
+    {
+        return $this->setParameter('buyerName', $value);
+    }
+
+    public function getBuyerAddress1()
+    {
+        return $this->getParameter('buyerAddress1');
+    }
+
+    public function setBuyerAddress1($value)
+    {
+        return $this->setParameter('buyerAddress1', $value);
+    }
+
+    public function getBuyerAddress2()
+    {
+        return $this->getParameter('buyerAddress2');
+    }
+
+    public function setBuyerAddress2($value)
+    {
+        return $this->setParameter('buyerAddress2', $value);
+    }
+
+    public function getBuyerCity()
+    {
+        return $this->getParameter('buyerCity');
+    }
+
+    public function setBuyerCity($value)
+    {
+        return $this->setParameter('buyerCity', $value);
+    }
+
+    public function getBuyerState()
+    {
+        return $this->getParameter('buyerState');
+    }
+
+    public function setBuyerState($value)
+    {
+        return $this->setParameter('buyerState', $value);
+    }
+
+    public function getBuyerZip()
+    {
+        return $this->getParameter('buyerZip');
+    }
+
+    public function setBuyerZip($value)
+    {
+        return $this->setParameter('buyerZip', $value);
+    }
+
+    public function getBuyerCountry()
+    {
+        return $this->getParameter('buyerCountry');
+    }
+
+    public function setBuyerCountry($value)
+    {
+        return $this->setParameter('buyerCountry', $value);
+    }
+
+    public function getBuyerEmail()
+    {
+        return $this->getParameter('buyerEmail');
+    }
+
+    public function setBuyerEmail($value)
+    {
+        return $this->setParameter('buyerEmail', $value);
+    }
+
+    public function getBuyerPhone()
+    {
+        return $this->getParameter('buyerPhone');
+    }
+
+    public function setBuyerPhone($value)
+    {
+        return $this->setParameter('buyerPhone', $value);
+    }
+
     public function getData()
     {
         $this->validate('amount', 'currency');
 
-        $data = array();
-        $data['price'] = $this->getAmount();
-        $data['currency'] = $this->getCurrency();
-        $data['posData'] = $this->getTransactionId();
-        $data['itemDesc'] = $this->getDescription();
-        $data['notificationURL'] = $this->getNotifyUrl();
-        $data['redirectURL'] = $this->getReturnUrl();
+        $data = [
+            'price' => $this->getAmount(),
+            'currency' => $this->getCurrency(),
+            'posData' => $this->getTransactionId(),
+            'itemDesc' => $this->getDescription(),
+            'notificationURL' => $this->getNotifyUrl(),
+            'redirectURL' => $this->getReturnUrl(),
+            'notificationEmail' => $this->getNotifyEmail(),
+            'fullNotifications' => $this->getFullNotifications(),
+            'transactionSpeed' => $this->getTransactionSpeed(),
+            'orderID' => $this->getOrderId(),
+            'itemCode' => $this->getItemCode(),
+            'physical' => $this->getPhysical(),
+            'buyerName' => $this->getBuyerName(),
+            'buyerAddress1' => $this->getBuyerAddress1(),
+            'buyerAddress2' => $this->getBuyerAddress2(),
+            'buyerCity' => $this->getBuyerCity(),
+            'buyerState' => $this->getBuyerState(),
+            'buyerZip' => $this->getBuyerZip(),
+            'buyerCountry' => $this->getBuyerCountry(),
+            'buyerEmail' => $this->getBuyerEmail(),
+            'buyerPhone' => $this->getBuyerPhone(),
+        ];
 
         return $data;
     }

--- a/tests/Omnipay/BitPay/Message/PurchaseRequestTest.php
+++ b/tests/Omnipay/BitPay/Message/PurchaseRequestTest.php
@@ -6,6 +6,11 @@ use Omnipay\Tests\TestCase;
 
 class PurchaseRequestTest extends TestCase
 {
+    /**
+     * @var \Omnipay\BitPay\Message\PurchaseRequest
+     */
+    private $request;
+
     public function setUp()
     {
         $this->request = new PurchaseRequest($this->getHttpClient(), $this->getHttpRequest());
@@ -23,15 +28,18 @@ class PurchaseRequestTest extends TestCase
                 'orderId' => '5',
                 'itemCode' => '123-11-123',
                 'physical' => false,
-                'buyerName' => 'John Doe',
-                'buyerAddress1' => 'Address Line 1',
-                'buyerAddress2' => 'Address Line 2',
-                'buyerCity' => 'Bitcoin City',
-                'buyerState' => 'Bitcoinaho',
-                'buyerZip' => 'SAMPLE-ZIP',
-                'buyerCountry' => 'Bitcoin Islands',
-                'buyerEmail' => 'buyer@example.com',
-                'buyerPhone' => '00-00000000',
+                'card' => array(
+                    'firstName' => 'John',
+                    'lastName' => 'Doe',
+                    'email' => 'buyer@example.com',
+                    'billingAddress1' => 'Address Line 1',
+                    'billingAddress2' => 'Address Line 2',
+                    'billingCity' => 'Bitcoin City',
+                    'billingState' => 'Bitcoinaho',
+                    'billingPostcode' => 'SAMPLE-ZIP',
+                    'billingCountry' => 'Bitcoin Islands',
+                    'billingPhone' => '00-00000000',
+                ),
             )
         );
     }

--- a/tests/Omnipay/BitPay/Message/PurchaseRequestTest.php
+++ b/tests/Omnipay/BitPay/Message/PurchaseRequestTest.php
@@ -17,6 +17,21 @@ class PurchaseRequestTest extends TestCase
                 'description' => 'thing',
                 'notifyUrl' => 'https://www.example.com/notify',
                 'returnUrl' => 'https://www.example.com/return',
+                'notifyEmail' => 'merchant@example.com',
+                'fullNotifications' => false,
+                'transactionSpeed' => 'medium',
+                'orderId' => '5',
+                'itemCode' => '123-11-123',
+                'physical' => false,
+                'buyerName' => 'John Doe',
+                'buyerAddress1' => 'Address Line 1',
+                'buyerAddress2' => 'Address Line 2',
+                'buyerCity' => 'Bitcoin City',
+                'buyerState' => 'Bitcoinaho',
+                'buyerZip' => 'SAMPLE-ZIP',
+                'buyerCountry' => 'Bitcoin Islands',
+                'buyerEmail' => 'buyer@example.com',
+                'buyerPhone' => '00-00000000',
             )
         );
     }
@@ -31,6 +46,21 @@ class PurchaseRequestTest extends TestCase
         $this->assertSame('thing', $data['itemDesc']);
         $this->assertSame('https://www.example.com/notify', $data['notificationURL']);
         $this->assertSame('https://www.example.com/return', $data['redirectURL']);
+        $this->assertSame('merchant@example.com', $data['notificationEmail']);
+        $this->assertFalse($data['fullNotifications']);
+        $this->assertSame('medium', $data['transactionSpeed']);
+        $this->assertSame('5', $data['orderID']);
+        $this->assertSame('123-11-123', $data['itemCode']);
+        $this->assertFalse($data['physical']);
+        $this->assertSame('John Doe', $data['buyerName']);
+        $this->assertSame('Address Line 1', $data['buyerAddress1']);
+        $this->assertSame('Address Line 2', $data['buyerAddress2']);
+        $this->assertSame('Bitcoin City', $data['buyerCity']);
+        $this->assertSame('Bitcoinaho', $data['buyerState']);
+        $this->assertSame('SAMPLE-ZIP', $data['buyerZip']);
+        $this->assertSame('Bitcoin Islands', $data['buyerCountry']);
+        $this->assertSame('buyer@example.com', $data['buyerEmail']);
+        $this->assertSame('00-00000000', $data['buyerPhone']);
     }
 
     public function testSend()


### PR DESCRIPTION
On [BitPay API Docs](https://bitpay.com/downloads/bitpayApi.pdf), in "Create an Invoice" section you can read about parameters that could be passed to their API during invoice creation. Unfortunately those parameters are missing in current Omnipay BitPay library. This pull request provides an ability to pass them from the user-code.
