### PR TITLE
Fixed thephpleague/omnipay-bitpay#4

### DIFF
--- a/src/Message/PurchaseResponse.php
+++ b/src/Message/PurchaseResponse.php
@@ -23,9 +23,7 @@ class PurchaseResponse extends AbstractResponse implements RedirectResponseInter
     public function getMessage()
     {
         if (isset($this->data['error'])) {
-            $msgs = implode(', ', $this->data['error']['messages']);
-
-            return $this->data['error']['message']." ($msgs)";
+            return $this->data['error']['type'] . ': ' . $this->data['error']['message'];
         }
     }
 

--- a/tests/Message/PurchaseResponseTest.php
+++ b/tests/Message/PurchaseResponseTest.php
@@ -27,7 +27,7 @@ class PurchaseResponseTest extends TestCase
 
         $this->assertFalse($response->isSuccessful());
         $this->assertFalse($response->isRedirect());
-        $this->assertSame('One or more fields is invalid (invalid currency code)', $response->getMessage());
+        $this->assertSame('limitExceeded: Invoice not created due to account limits, please check your approval levels', $response->getMessage());
         $this->assertNull($response->getTransactionReference());
         $this->assertNull($response->getRedirectUrl());
         $this->assertNull($response->getRedirectData());

--- a/tests/Mock/PurchaseFailure.txt
+++ b/tests/Mock/PurchaseFailure.txt
@@ -8,4 +8,4 @@ Set-Cookie: __cfduid=d348c68db92d5d2687232670daf4c62891390369901287; expires=Mon
 X-Powered-By: Express
 CF-RAY: f09f94b08f104b6
 
-{"error":{"type":"validationError","message":"One or more fields is invalid","messages":{"currency":"invalid currency code"}}}
+{"error":{"type":"limitExceeded","message":"Invoice not created due to account limits, please check your approval levels"}}


### PR DESCRIPTION
Fixed PurchaseResponse to correctly return an error message when it occures following [BitPay API speficications](https://bitpay.com/downloads/bitpayApi.pdf):

> All error responses will have an "error" field that is an object with two fields called "type" and "message".
